### PR TITLE
Fixed type ahead & blockui conflict

### DIFF
--- a/src/app/app.config.js
+++ b/src/app/app.config.js
@@ -12,6 +12,12 @@
     });
 
     blockUIConfig.template = '<div class="block-ui-overlay"></div><div class="box-loading"></div>';
+    blockUIConfig.requestFilter = function(config) {
+        if (!config.params || config.params.blockUi === undefined)
+            return true;
+        
+        return config.params.blockUi;
+    };
 
     hotkeysProvider.templateTitle = 'Raccourcis clavier';
     hotkeysProvider.cheatSheetDescription = "Affiche / masque ce menu d'aide";

--- a/src/app/core/resource.decorator.js
+++ b/src/app/core/resource.decorator.js
@@ -23,6 +23,13 @@
       },
       query: {
         method: 'GET',
+        params: {
+            /** 
+             * Specify if block-ui should be displayed for that request
+             * Used for typeahead (block-ui is making a blur which prevent the typeahead to display data properly)
+            **/
+            blockUi: true  
+        },
         transformResponse: function(data, headers) {
           return {
             data: JSON.parse(data),


### PR DESCRIPTION
Typeahead was always focused out by block-ui with a blur event.
Fixed by adding a flag to the url query to prevent block-ui from
starting
